### PR TITLE
Update Feedback Hub link to launch Feedback Hub directly to WSA App Feedback page

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 blank_issues_enabled: false
 contact_links:
   - name: "Windows Feedback Hub for end-user feedback"
-    url: https://aka.ms/
+    url: feedback-hub:
     about: If you have issues and feedback on the subsystem for non-developer topics, please use Windows Feedback Hub
  

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 blank_issues_enabled: false
 contact_links:
   - name: "Windows Feedback Hub for end-user feedback"
-    url: feedback-hub:
+    url: feedback-hub:?appid=MicrosoftCorporationII.WindowsSubsystemForAndroid_8wekyb3d8bbwe!App
     about: If you have issues and feedback on the subsystem for non-developer topics, please use Windows Feedback Hub
  

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 blank_issues_enabled: false
 contact_links:
   - name: "Windows Feedback Hub for end-user feedback"
-    url: http://aka.ms
+    url: http://aka.ms/FeedbackHub?appid=MicrosoftCorporationII.WindowsSubsystemForAndroid_8wekyb3d8bbwe!App
     about: If you have issues and feedback on the subsystem for non-developer topics, please use Windows Feedback Hub
  

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 blank_issues_enabled: false
 contact_links:
   - name: "Windows Feedback Hub for end-user feedback"
-    url: feedback-hub:?appid=MicrosoftCorporationII.WindowsSubsystemForAndroid_8wekyb3d8bbwe!App
+    url: http://aka.ms
     about: If you have issues and feedback on the subsystem for non-developer topics, please use Windows Feedback Hub
  


### PR DESCRIPTION
The URL linking to Feedback Hub in the issues template didn't navigate to Feedback Hub.  This change updates the template to point directly to the Feedback Hub submission page for WSA.

I tested this in my own fork by navigating to: https://github.com/philnach/WSA/issues/new/choose and clicking on the Open link button for the "Windows Feedback Hub for end-user feedback" entry.  

With the new URL Windows Feedback Hub is launched to the Windows Subsystem for Android app entry.